### PR TITLE
trying to get to work with matrices . . .

### DIFF
--- a/src/CommonSubexpressions.jl
+++ b/src/CommonSubexpressions.jl
@@ -40,6 +40,8 @@ const standard_expression_forms = Set{Symbol}(
      :for,
      :ref,
      :macrocall,
+     :vcat,
+     :row,
      Symbol("'")))
 
 const assignment_expression_forms = Set{Symbol}(


### PR DESCRIPTION
Added vcat and row to standard_expression_forms

This is my attempt to fix the issue I've raised.

So far I got it to work like this:

```
prog = "function mtx(x1,x2,x3,x4) \n [x1*x4 x2; x3 x1*x4] \n end"
ex = parse(prog)
exx = cse(ex)
```

with ex, and exx being:

```
julia> ex
:(function mtx(x1, x2, x3, x4) # none, line 2:
        [x1 * x4 x2; x3 x1 * x4]
    end)
```
```
julia> exx
quote
    function mtx(x1, x2, x3, x4)
        ##*#665 = x1 * x4
        begin  # none, line 2:
            [##*#665 x2; x3 ##*#665]
        end
    end
end
```

I'm not sure if this will work when called as a macro, but this seems to work at least for my use case above...

