### PR TITLE
add flag to disable warnings

### DIFF
--- a/src/CommonSubexpressions.jl
+++ b/src/CommonSubexpressions.jl
@@ -24,7 +24,7 @@ disqualify!(cache::Cache, s::Symbol) = push!(cache.disqualified_symbols, s)
 disqualify!(cache::Cache, expr::Expr) = foreach(arg -> disqualify!(cache, arg), expr.args)
 
 # fallback for non-Expr arguments
-combine_subexprs!(setup, expr) = expr
+combine_subexprs!(setup, expr, warn_enabled::Bool) = expr
 
 const standard_expression_forms = Set{Symbol}(
     (:call,
@@ -49,31 +49,31 @@ const assignment_expression_forms = Set{Symbol}(
      :(*=),
      :(/=)))
 
-function combine_subexprs!(cache::Cache, expr::Expr)
+function combine_subexprs!(cache::Cache, expr::Expr, warn_enabled::Bool)
     if expr.head == :function
         # We can't continue CSE through a function definition, but we can
         # start over inside the body of the function:
         for i in 2:length(expr.args)
-            expr.args[i] = combine_subexprs!(expr.args[i])
+            expr.args[i] = combine_subexprs!(expr.args[i], warn_enabled)
         end
     elseif expr.head == :line
         # nothing
     elseif expr.head in assignment_expression_forms
         disqualify!(cache, expr.args[1])
         for i in 2:length(expr.args)
-            expr.args[i] = combine_subexprs!(cache, expr.args[i])
+            expr.args[i] = combine_subexprs!(cache, expr.args[i], warn_enabled)
         end
     elseif expr.head == :generator
         for i in vcat(2:length(expr.args), 1)
-            expr.args[i] = combine_subexprs!(cache, expr.args[i])
+            expr.args[i] = combine_subexprs!(cache, expr.args[i], warn_enabled)
         end
     elseif expr.head in standard_expression_forms
         for (i, child) in enumerate(expr.args)
-            expr.args[i] = combine_subexprs!(cache, child)
+            expr.args[i] = combine_subexprs!(cache, child, warn_enabled)
         end
         if expr.head == :call
             for (i, child) in enumerate(expr.args)
-                expr.args[i] = combine_subexprs!(cache, child)
+                expr.args[i] = combine_subexprs!(cache, child, warn_enabled)
             end
             if all(!isa(arg, Expr) && !(arg in cache.disqualified_symbols) for arg in expr.args)
                 combined_args = Symbol(expr.args...)
@@ -87,25 +87,25 @@ function combine_subexprs!(cache::Cache, expr::Expr)
             end
         end
     else
-        warn("CommonSubexpressions can't yet handle expressions of this form: $(expr.head)")
+        warn_enabled && warn("CommonSubexpressions can't yet handle expressions of this form: $(expr.head)")
     end
     return expr
 end
 
-combine_subexprs!(x) = x
+combine_subexprs!(x, warn_enabled::Bool = true) = x
 
-function combine_subexprs!(expr::Expr)
+function combine_subexprs!(expr::Expr, warn_enabled::Bool)
     cache = Cache()
-    expr = combine_subexprs!(cache, expr)
+    expr = combine_subexprs!(cache, expr, warn_enabled)
     Expr(:block, cache.setup..., expr)
 end
 
-macro cse(expr)
-    result = combine_subexprs!(expr)
+macro cse(expr, warn_enabled::Bool = true)
+    result = combine_subexprs!(expr, warn_enabled)
     # println(result)
     esc(result)
 end
 
-cse(expr) = combine_subexprs!(copy(expr))
+cse(expr, warn_enabled::Bool = true) = combine_subexprs!(copy(expr), warn_enabled)
 
 end


### PR DESCRIPTION
First of all, thanks for this package - it works great for auto-CSEing dual number primitive definitions in ForwardDiff.

After https://github.com/JuliaDiff/DiffRules.jl/pull/11, some of these primitive definitions contain `if` statements, which basically means that whenever somebody loads ForwardDiff for this first time, they see a bunch of:

```
WARNING: CommonSubexpressions can't yet handle expressions of this form: if
```

For ForwardDiff's case, I don't mind if CSE can't be applied to an expression - I'm fine with this package just trying its best and handing me whatever the result is. Thus, this PR will allow me to disable this warning so users don't get scared.

If you could get a new tag quickly after this is merged, I'd be super appreciative. If that's too complicated, right now, though, I can hack around this warning in ForwardDiff in the meantime.
