### PR TITLE
Break chains 1*2*3 into pairs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "CommonSubexpressions"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+authors = ["Robin Deits"]
+version = "0.2.1"
+
+[compat]
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,3 +143,14 @@ end
     @test y == 3
     @test x == 4
 end
+
+@testset "trinary" begin
+    expr = cse(:(x*y*z))
+    @test expr.head == :block
+    @test expr.args[1].args[2] == :(y * z)
+    @test expr.args[2].args[2].args[2] == :x
+    @test expr.args[3] isa Symbol
+    x,y,z,t = 1,2,3,4
+    @test x*y*z*t == @cse x*y*z*t
+    @test x+y+z+t == @cse x+y+z+t
+end


### PR DESCRIPTION
This breaks `1*2*3` into `1*(2*3)`, which may partially address #14. Are there any downsides to doing this?