### PR TITLE
WIP: implement binarization and improve macro expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
-  - 1.0
+  - 1
   - 1.4
   - nightly
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonSubexpressions"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 authors = ["Robin Deits <robin.deits@gmail.com>"]
-version = "0.2.1"
+version = "0.3"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -9,4 +9,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MacroTools = "0.5"
-julia = "0.7, 1"
+julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["Robin Deits <robin.deits@gmail.com>"]
 version = "0.2.1"
 
 [deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+MacroTools = "0.5"
 julia = "0.7, 1"

--- a/src/CommonSubexpressions.jl
+++ b/src/CommonSubexpressions.jl
@@ -25,7 +25,7 @@ disqualify!(cache::Cache, s::Symbol) = push!(cache.disqualified_symbols, s)
 disqualify!(cache::Cache, expr::Expr) = foreach(arg -> disqualify!(cache, arg), expr.args)
 
 # fallback for non-Expr arguments
-combine_subexprs!(setup, x, mod::Module, warn_enabled::Bool) = x
+combine_subexprs!(setup, x, warn_enabled::Bool) = x
 
 const standard_expression_forms = Set{Symbol}(
     (:call,
@@ -50,33 +50,37 @@ const assignment_expression_forms = Set{Symbol}(
      :(*=),
      :(/=)))
 
-function combine_subexprs!(cache::Cache, expr::Expr, mod::Module, warn_enabled::Bool)
+function combine_subexprs!(cache::Cache, expr::Expr, warn_enabled::Bool)
     if expr.head == :macrocall
-        return combine_subexprs!(cache, macroexpand(mod, expr), mod, warn_enabled)
+        # We don't recursively expand other macros, but we can perform CSE on
+        # the expression inside the macro call.
+        for i in 2:length(expr.args)
+            expr.args[i] = combine_subexprs!(expr.args[i], warn_enabled)
+        end
     elseif expr.head == :function
         # We can't continue CSE through a function definition, but we can
         # start over inside the body of the function:
         for i in 2:length(expr.args)
-            expr.args[i] = combine_subexprs!(expr.args[i], mod, warn_enabled)
+            expr.args[i] = combine_subexprs!(expr.args[i], warn_enabled)
         end
     elseif expr.head == :line
         # nothing
     elseif expr.head in assignment_expression_forms
         disqualify!(cache, expr.args[1])
         for i in 2:length(expr.args)
-            expr.args[i] = combine_subexprs!(cache, expr.args[i], mod, warn_enabled)
+            expr.args[i] = combine_subexprs!(cache, expr.args[i], warn_enabled)
         end
     elseif expr.head == :generator
         for i in vcat(2:length(expr.args), 1)
-            expr.args[i] = combine_subexprs!(cache, expr.args[i], mod, warn_enabled)
+            expr.args[i] = combine_subexprs!(cache, expr.args[i], warn_enabled)
         end
     elseif expr.head in standard_expression_forms
         for (i, child) in enumerate(expr.args)
-            expr.args[i] = combine_subexprs!(cache, child, mod, warn_enabled)
+            expr.args[i] = combine_subexprs!(cache, child, warn_enabled)
         end
         if expr.head == :call
             for (i, child) in enumerate(expr.args)
-                expr.args[i] = combine_subexprs!(cache, child, mod, warn_enabled)
+                expr.args[i] = combine_subexprs!(cache, child, warn_enabled)
             end
             if all(!isa(arg, Expr) && !(arg in cache.disqualified_symbols) for arg in drop(expr.args, 1))
                 combined_args = Symbol(expr.args...)
@@ -95,16 +99,28 @@ function combine_subexprs!(cache::Cache, expr::Expr, mod::Module, warn_enabled::
     return expr
 end
 
-combine_subexprs!(x, mod::Module, warn_enabled::Bool = true) = x
+combine_subexprs!(x, warn_enabled::Bool = true) = x
 
-function combine_subexprs!(expr::Expr, mod::Module, warn_enabled::Bool)
+function combine_subexprs!(expr::Expr, warn_enabled::Bool)
     cache = Cache()
-    expr = combine_subexprs!(cache, expr, mod, warn_enabled)
+    expr = combine_subexprs!(cache, expr, warn_enabled)
     Expr(:block, cache.setup..., expr)
 end
 
+"""
+    @cse(expr, warn_enabled = true)
+
+Perform naive common subexpression elimination under the assumption
+that all functions called withing the body of the macro are pure,
+meaning that they have no side effects. See [Readme.md](https://github.com/rdeits/CommonSubexpressions.jl/blob/master/Readme.md)
+for more details.
+
+If `warn_enabled == true`, then this macro will warn whenever it encounters
+an expression type that it does not know how to transform. Otherwise that
+expression will be silently left unmodified.
+"""
 macro cse(expr, warn_enabled::Bool = true)
-    result = combine_subexprs!(expr, __module__, warn_enabled)
+    result = combine_subexprs!(expr, warn_enabled)
     # println(result)
     esc(result)
 end
@@ -113,7 +129,7 @@ cse(expr, warn_enabled::Bool = true) = combine_subexprs!(copy(expr), warn_enable
 
 function _binarize(expr::Expr)
     if @capture(expr, f_(a_, b_, c_, args__))
-        :($f($f($a, $b), $c, $(args...)))
+        _binarize(:($f($f($a, $b), $c, $(args...))))
     else
         expr
     end
@@ -124,12 +140,24 @@ _binarize(x) = x
 binarize(expr::Expr) = postwalk(_binarize, expr)
 binarize(x) = x
 
-macro binarize(expr)
-    println("generic: $expr")
-end
+"""
+    @binarize(expr::Expr)
 
+Convery all n-ary function calls within the given expression to nested binary
+calls to the same function. That is, convert all calls of the form `f(a, b, c)`
+to `f(f(a, b), c)` with as many layers of nesting as necessary. Operators like
+`+` and `*` are handled just like any other function call, so
+
+    @binarize a + b + c + d
+
+will produce:
+
+    ((a + b) + c) + d
+
+This is intended to make subexpression elimination easier for long chained
+function calls, such as https://github.com/rdeits/CommonSubexpressions.jl/issues/14
+"""
 macro binarize(expr::Expr)
-    @show expr
     esc(binarize(expr))
 end
 


### PR DESCRIPTION
Implements `@binarize` which converts all N-ary function calls `f(a, b, c)` into nested binary calls `f(a, b), c)`. This is intended to help with https://github.com/rdeits/CommonSubexpressions.jl/issues/14#issuecomment-621470076 without quite as much magic as #16 . This PR also fixes (I think?) recursive macro expansion, so you can do:

```julia
@cse @binarize a + b + c
```

or even:

```julia
@cse @binarize @fastmath a + b + c
```

TODO: 
- [x] Tests
- [x] Check macro expansion when not running in Main