### PR TITLE
Fix an invalidation

### DIFF
--- a/src/CommonSubexpressions.jl
+++ b/src/CommonSubexpressions.jl
@@ -87,7 +87,7 @@ function combine_subexprs!(cache::Cache, expr::Expr;
             for (i, child) in enumerate(expr.args)
                 expr.args[i] = combine_subexprs!(cache, child, warn=warn, mod=mod)
             end
-            if all(!isa(arg, Expr) && !(arg in cache.disqualified_symbols) for arg in drop(expr.args, 1))
+            if all(!isa(arg, Expr) && !(isa(arg, Symbol) && arg in cache.disqualified_symbols) for arg in drop(expr.args, 1))
                 combined_args = Symbol(expr.args...)
                 if !haskey(cache.args_to_symbol, combined_args)
                     sym = add_element!(cache, combined_args, expr)


### PR DESCRIPTION
The cause was a new method in SciMLBase.jl:
```
julia> tree
inserting ==(retcode::SciMLBase.ReturnCode.T, s::Symbol) @ SciMLBase ~/.julia/packages/SciMLBase/QqtZA/src/retcodes.jl:348 invalidated:
```
This accounts for only ~20 invalidations, but seems worth having.